### PR TITLE
make dist folders when installing and add import

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": false,
   "scripts": {
     "build": "tsc",
-    "prepare": "yarn run build",
+    "prepublish": "yarn run build",
     "format": "prettier src --check --write"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": false,
   "scripts": {
     "build": "tsc",
-    "prepublish": "yarn run build",
+    "prepare": "yarn run build",
     "format": "prettier src --check --write"
   },
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-type Level = "VERBOSE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL";
+export type Level = "VERBOSE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL";
 
 type Scopes = { [key: string]: Level };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "types": ["node"],
     "skipLibCheck": true
   },
+  "include": ["src"],
   "exclude": [
     "node_modules",
     "dist"


### PR DESCRIPTION
prepublish is deprecated and doesn't run anymore. So while importing I couldn't use the package as intended 
import logger from "logger-js"  would give this error message but using logger-js/src would work but I don't think that is correct.

<img width="836" alt="Screenshot 2023-05-30 at 09 52 33" src="https://github.com/Magnetme/logger-js/assets/9051543/825c0ca4-16d6-42b4-ab3a-afd49d9a9047">

I also needed Level in multiple place so I've exported that too.

https://docs.npmjs.com/cli/v8/using-npm/scripts?v=true