### PR TITLE
making the package typeable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "@magnet.me/logger-js",
-  "version": "1.0.1",
-  "main": "dist/index.js",
+  "version": "1.0.2",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
   "repository": "https://github.com/Magnetme/logger-js",
   "author": "Magnet.me",
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
     "prepublish": "yarn run build",
     "format": "prettier src --check --write"
   },

--- a/tsconfig-cjs.json
+++ b/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs"
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es2016",
+    "target": "es3",
     "module": "esnext",
     "moduleResolution": "node",
     "lib": ["es2019"],
     "declaration": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "strict": true,
     "esModuleInterop": true,
     "types": ["node"],


### PR DESCRIPTION
the dist now exists out of a module and a main. The main is transpilled to esnext and the module to common js. This way tests are now runable in the web-app

I've used this approach in the end. https://blog.logrocket.com/publishing-node-modules-typescript-es-modules/